### PR TITLE
change OL8's Dockerfile to use dnf instead of yum

### DIFF
--- a/hysds/Dockerfile
+++ b/hysds/Dockerfile
@@ -5,7 +5,6 @@ ARG VERSION="3.9.5"
 
 WORKDIR $HOME
 
-# RUN yum update -y && \
 RUN yum install gcc openssl-devel bzip2-devel libffi-devel openldap-devel readline-devel make wget git -y && \
   cd /tmp && \
   # installing python 3
@@ -32,12 +31,12 @@ RUN cd $HOME && \
   pip3 install --no-cache-dir -e hysds_commons/ && \
   pip3 install --no-cache-dir -e hysds/ && \
   yum clean all && \
-  rm -rf /var/cache/yum && \
+  rm -r /var/cache/* && \
   rm -r /tmp/*
 
-# # osaka/  # installs Werkzeug 2.0.1
-# # https://github.com/hysds/osaka/blob/develop/setup.py#L28
-# # https://github.com/spulec/moto/blob/master/setup.py#L39
+# osaka/  # installs Werkzeug 2.0.1
+# https://github.com/hysds/osaka/blob/develop/setup.py#L28
+# https://github.com/spulec/moto/blob/master/setup.py#L39
 
 WORKDIR $HOME
 CMD ["/bin/bash"]

--- a/hysds/Dockerfile.ol8
+++ b/hysds/Dockerfile.ol8
@@ -5,8 +5,8 @@ ARG VERSION="3.9.5"
 
 WORKDIR $HOME
 
-# RUN yum update -y && \
-RUN yum install gcc tar openssl-devel bzip2-devel libffi-devel openldap-devel readline-devel make wget git -y && \
+RUN dnf update -y && \
+  dnf install gcc tar openssl-devel bzip2-devel libffi-devel openldap-devel readline-devel make wget git -y && \
   cd /tmp && \
   # installing python 3
   wget https://www.python.org/ftp/python/${VERSION}/Python-${VERSION}.tgz && \
@@ -31,13 +31,13 @@ RUN cd $HOME && \
   pip3 install --no-cache-dir -e osaka/ && \
   pip3 install --no-cache-dir -e hysds_commons/ && \
   pip3 install --no-cache-dir -e hysds/ && \
-  yum clean all && \
-  rm -rf /var/cache/yum && \
-  rm -r /tmp/*
+  dnf clean all && \
+  rm -rf /var/cache/* && \
+  rm -rf /tmp/*
 
-# # osaka/  # installs Werkzeug 2.0.1
-# # https://github.com/hysds/osaka/blob/develop/setup.py#L28
-# # https://github.com/spulec/moto/blob/master/setup.py#L39
+# osaka/  # installs Werkzeug 2.0.1
+# https://github.com/hysds/osaka/blob/develop/setup.py#L28
+# https://github.com/spulec/moto/blob/master/setup.py#L39
 
 WORKDIR $HOME
 CMD ["/bin/bash"]


### PR DESCRIPTION
`dnf` is a more modern replacement for `yum` so i figured we should start using it

- renamed `Dockerfile-ol8` to `Dockerfile.ol8`
- removed more cache in the Dockerfiles