### PR TITLE
fixing Elasticsearch (helm) to withstand more traffic

### DIFF
--- a/hysds/README.md
+++ b/hysds/README.md
@@ -75,7 +75,7 @@ kubectl.docker create configmap logstash-configs \
 ```
 
 ```bash
-$ kubectl.docker get cm
+$ kubectl get cm
 NAME               DATA   AGE
 celeryconfig       1      8m25s
 logstash-configs   6      5s

--- a/hysds/mozart/elasticsearch/values-override.yml
+++ b/hysds/mozart/elasticsearch/values-override.yml
@@ -3,16 +3,16 @@
 antiAffinity: "soft"
 
 # Shrink default JVM heap.
-esJavaOpts: "-Xmx128m -Xms128m"
+esJavaOpts: "-Xmx512m -Xms512m"
 
 # Allocate smaller chunks of memory per pod.
 resources:
   requests:
-    cpu: "100m"
-    memory: "512M"
+    cpu: "1000m"
+    memory: "2Gi"
   limits:
     cpu: "1000m"
-    memory: "512M"
+    memory: "2Gi"
 
 # Request smaller persistent volumes.
 volumeClaimTemplate:
@@ -20,10 +20,13 @@ volumeClaimTemplate:
   storageClassName: "hostpath"
   resources:
     requests:
-      storage: 100M
+      storage: 5Gi
 
 # elasticsearch:
 masterService: "mozart-es"
+
+# because we're using 1 node the cluster health will be YELLOW instead of GREEN after data is ingested
+clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
 
 replicas: 1
 


### PR DESCRIPTION
- increased memory and storage sizes in `values-override.yml`
- added `clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"` to `values-override.yml` b/c the cluster status becomes `YELLOW` when using only 1 node
- [all tune-able values](https://github.com/elastic/helm-charts/tree/main/elasticsearch)
- [default helm values](https://github.com/elastic/helm-charts/blob/main/elasticsearch/values.yaml)

Running ES in helm with the current values would crash after 10-15 min
i suspect it was related to limited memory and persistent volume sizes specified in `values-override.yml`

by default Kubernetes will restart the pod when it crashes, but it gets stuck in a limbo state where ES is running in the pod, but k8 deems it unstable b/c the cluster status returned is `YELLOW` and not `GREEN`, therefore other pods would not be able to communicate with it
```bash
$ kubectl.docker describe elasticsearch-master-0
.
.
.
Events:
  Type     Reason            Age                   From               Message
  ----     ------            ----                  ----               -------
  Warning  FailedScheduling  44m (x2 over 44m)     default-scheduler  0/1 nodes are available: 1 pod has unbound immediate PersistentVolumeClaims.
  Normal   Scheduled         44m                   default-scheduler  Successfully assigned default/elasticsearch-master-0 to docker-desktop
  Normal   Pulled            44m                   kubelet            Container image "docker.elastic.co/elasticsearch/elasticsearch:7.9.3" already present on machine
  Normal   Created           44m                   kubelet            Created container configure-sysctl
  Normal   Started           44m                   kubelet            Started container configure-sysctl
  Warning  Unhealthy         25m                   kubelet            Readiness probe failed: Elasticsearch is already running, lets check the node is healthy
  Warning  Unhealthy         25m                   kubelet            Readiness probe errored: rpc error: code = Unknown desc = container not running (97ab9a0717507f3a3d3247784de13de6668c49d5747e37139d90d757514384b1)
  Normal   Pulled            25m (x2 over 44m)     kubelet            Container image "docker.elastic.co/elasticsearch/elasticsearch:7.9.3" already present on machine
  Normal   Created           25m (x2 over 44m)     kubelet            Created container elasticsearch
  Normal   Started           25m (x2 over 44m)     kubelet            Started container elasticsearch
  Warning  Unhealthy         4m3s (x129 over 43m)  kubelet            Readiness probe failed: Waiting for elasticsearch cluster to become ready (request params: "wait_for_status=green&timeout=1s" )
```

```bash
$ curl -i "localhost:9200/_cluster/health?pretty&wait_for_status=green&timeout=1s"
HTTP/1.1 408 Request Timeout
content-type: application/json; charset=UTF-8
content-length: 465

{
  "cluster_name" : "elasticsearch",
  "status" : "yellow",
  "timed_out" : true,
  "number_of_nodes" : 1,
  "number_of_data_nodes" : 1,
  "active_primary_shards" : 1,
  "active_shards" : 1,
  "relocating_shards" : 0,
  "initializing_shards" : 0,
  "unassigned_shards" : 1,
  "delayed_unassigned_shards" : 0,
  "number_of_pending_tasks" : 0,
  "number_of_in_flight_fetch" : 0,
  "task_max_waiting_in_queue_millis" : 0,
  "active_shards_percent_as_number" : 50.0
}
```

after changing the changing/adding values in `values-overide.yml` the pod hasn't crashed and the cluster was able to run for over an hour before i shut it down
```bash
$ kubectl.docker get pods elasticsearch-master-0
NAME                     READY   STATUS    RESTARTS   AGE
elasticsearch-master-0   1/1     Running   0          79m


$ curl "http://localhost:9200/_cat/indices?v"
health status index              uuid                   pri rep docs.count docs.deleted store.size pri.store.size
yellow open   job_status-current eEXgGuMBT9GqbQuKWYDSUQ   1   1      15409            0      6.1mb          6.1mb
```
