### PR TITLE
added grq's elasticsearch with helm

### DIFF
--- a/hysds/README.md
+++ b/hysds/README.md
@@ -88,6 +88,7 @@ mozart-settings    1      6m46s
 # downloading the helm charts from the repository
 helm repo add elastic https://helm.elastic.co
 
+# in the hysds/mozart/ directory
 # starting the cluster
 helm install mozart-es elastic/elasticsearch --version 7.9.3 -f elasticsearch/values-override.yml
 
@@ -98,9 +99,43 @@ helm uninstall mozart-es
 ```bash
 $ curl http://localhost:9200
 # {
-#   "name" : "elasticsearch-master-0",
-#   "cluster_name" : "elasticsearch",
-#   "cluster_uuid" : "zgdl-h2_TR68yOZwVWdUwA",
+#   "name" : "mozart-es-master-0",
+#   "cluster_name" : "mozart-es",
+#   "cluster_uuid" : "JrMWWXIWRvSsI-wjkx9MBg",
+#   "version" : {
+#     "number" : "7.9.3",
+#     "build_flavor" : "default",
+#     "build_type" : "docker",
+#     "build_hash" : "c4138e51121ef06a6404866cddc601906fe5c868",
+#     "build_date" : "2020-10-16T10:36:16.141335Z",
+#     "build_snapshot" : false,
+#     "lucene_version" : "8.6.2",
+#     "minimum_wire_compatibility_version" : "6.8.0",
+#     "minimum_index_compatibility_version" : "6.0.0-beta1"
+#   },
+#   "tagline" : "You Know, for Search"
+# }
+```
+
+#### Starting GRQ's Elasticsearch cluster
+```bash
+# downloading the helm charts from the repository
+helm repo add elastic https://helm.elastic.co
+
+# in the hysds/grq/ directory
+# starting the cluster
+helm install grq-es elastic/elasticsearch --version 7.9.3 -f elasticsearch/values-override.yml
+
+# tearing down the cluster
+helm uninstall grq-es
+```
+
+```bash
+$ curl http://localhost:9201
+# {
+#   "name" : "grq-es-master-0",
+#   "cluster_name" : "grq-es",
+#   "cluster_uuid" : "TWnGGEdKRJaWgkt6p3gtrA",
 #   "version" : {
 #     "number" : "7.9.3",
 #     "build_flavor" : "default",

--- a/hysds/celeryconfig.py
+++ b/hysds/celeryconfig.py
@@ -77,8 +77,8 @@ GRQ_UPDATE_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1/grq/dataset/in
 
 
 GRQ_AWS_ES = False
-GRQ_ES_HOST = "127.0.0.1"
-GRQ_ES_PORT = 9200
+GRQ_ES_HOST = "grq-es"
+GRQ_ES_PORT = 9201
 GRQ_ES_PROTOCOL = "http"
 GRQ_ES_URL = '%s://%s:%d' % (GRQ_ES_PROTOCOL, GRQ_ES_HOST, GRQ_ES_PORT)
 

--- a/hysds/grq/elasticsearch/values-override.yml
+++ b/hysds/grq/elasticsearch/values-override.yml
@@ -1,5 +1,5 @@
 ---
-clusterName: "mozart-es"
+clusterName: "grq-es"
 
 # Permit co-located instances for solitary minikube virtual machines.
 antiAffinity: "soft"
@@ -25,7 +25,7 @@ volumeClaimTemplate:
       storage: 5Gi
 
 # elasticsearch:
-masterService: "mozart-es"
+masterService: "grq-es"
 
 # because we're using 1 node the cluster health will be YELLOW instead of GREEN after data is ingested
 clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
@@ -35,10 +35,11 @@ replicas: 1
 service:
   type: "LoadBalancer"
 
-httpPort: 9200
-transportPort: 9300
+httpPort: 9201
+transportPort: 9301
 
 esConfig:
   elasticsearch.yml: |
     http.cors.enabled : true
     http.cors.allow-origin: "*"
+    http.port: 9201


### PR DESCRIPTION
- added more values to `grq` and `mozart`'s helm yaml file to allow for separation
  - `clusterName`, `httpPort` and `transportPort` values are used to separate the 2 ES's running
- mozart's elasticsearch is running on port `9200` and GRQ on `9201`

```bash
$ curl localhost:9200       
{
  "name" : "mozart-es-master-0",
  "cluster_name" : "mozart-es",
  "cluster_uuid" : "Cvmkbq5QRY2MaVCFwY8QeA",
  "version" : {
    "number" : "7.9.3",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "c4138e51121ef06a6404866cddc601906fe5c868",
    "build_date" : "2020-10-16T10:36:16.141335Z",
    "build_snapshot" : false,
    "lucene_version" : "8.6.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
$ curl localhost:9201
{
  "name" : "grq-es-master-0",
  "cluster_name" : "grq-es",
  "cluster_uuid" : "vIGyBaleSpS3-iF6_xDgVA",
  "version" : {
    "number" : "7.9.3",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "c4138e51121ef06a6404866cddc601906fe5c868",
    "build_date" : "2020-10-16T10:36:16.141335Z",
    "build_snapshot" : false,
    "lucene_version" : "8.6.2",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
```