### PR TITLE
adding Factotum job worker

### DIFF
--- a/hysds/README.md
+++ b/hysds/README.md
@@ -22,6 +22,12 @@ docker build . -t hysds-mozart:unity-v0.0.1
 docker build . -t celery-tasks:unity-v0.0.1
 ```
 
+#### Building the docker image for the factotum's job worker
+
+```bash
+docker build . -t factotum:unity-v0.0.1
+```
+
 ```bash
 $ docker images
 REPOSITORY           TAG                  IMAGE ID       CREATED              SIZE
@@ -29,8 +35,6 @@ hysds-mozart         unity-v0.0.1         dad6831f1b04   4 seconds ago        1.
 hysds-core           unity-v0.0.1         82a09dc4a50a   About a minute ago   997MB
 celery-tasks         unity-v0.0.1         a894468c7101   31 minutes ago       189MB
 ```
-
-# Running HySDS (Mozart) in K8
 
 #### Create the ConfigMap for `celeryconfig.py`
 
@@ -42,6 +46,8 @@ kubectl create configmap celeryconfig --from-file celeryconfig.py
 kubectl.docker create configmap celeryconfig --from-file celeryconfig.py
 ```
 
+# Mozart
+
 #### Create the ConfigMap for Mozart Rest APIs `settings.cfg`
 
 ```bash
@@ -50,16 +56,6 @@ kubectl create configmap mozart-settings --from-file ./mozart/rest_api/settings.
 
 # if using Docker desktop
 kubectl.docker create configmap mozart-settings --from-file ./mozart/rest_api/settings.cfg
-```
-
-#### Create the ConfigMap for Mozart Rest APIs `settings.cfg`
-
-```bash
-# in the hysds/ root directory
-kubectl create configmap grq2-settings --from-file ./grq/rest_api/settings.cfg
-
-# if using Docker desktop
-kubectl.docker create configmap grq2-settings --from-file ./grq/rest_api/settings.cfg
 ```
 
 #### Create ConfigMap for Logstash
@@ -112,41 +108,6 @@ $ curl http://localhost:9200
 #   "name" : "mozart-es-master-0",
 #   "cluster_name" : "mozart-es",
 #   "cluster_uuid" : "JrMWWXIWRvSsI-wjkx9MBg",
-#   "version" : {
-#     "number" : "7.9.3",
-#     "build_flavor" : "default",
-#     "build_type" : "docker",
-#     "build_hash" : "c4138e51121ef06a6404866cddc601906fe5c868",
-#     "build_date" : "2020-10-16T10:36:16.141335Z",
-#     "build_snapshot" : false,
-#     "lucene_version" : "8.6.2",
-#     "minimum_wire_compatibility_version" : "6.8.0",
-#     "minimum_index_compatibility_version" : "6.0.0-beta1"
-#   },
-#   "tagline" : "You Know, for Search"
-# }
-```
-
-#### Starting GRQ's Elasticsearch cluster
-
-```bash
-# downloading the helm charts from the repository
-helm repo add elastic https://helm.elastic.co
-
-# in the hysds/grq/ directory
-# starting the cluster
-helm install grq-es elastic/elasticsearch --version 7.9.3 -f elasticsearch/values-override.yml
-
-# tearing down the cluster
-helm uninstall grq-es
-```
-
-```bash
-$ curl http://localhost:9201
-# {
-#   "name" : "grq-es-master-0",
-#   "cluster_name" : "grq-es",
-#   "cluster_uuid" : "TWnGGEdKRJaWgkt6p3gtrA",
 #   "version" : {
 #     "number" : "7.9.3",
 #     "build_flavor" : "default",
@@ -275,40 +236,106 @@ health status index              uuid                   pri rep docs.count docs.
 yellow open   job_status-current QxnnmhokS5-Lw4t8GFxd-A   1   1         62            0     53.1kb         53.1kb
 ```
 
-#### All K8 resources
+# GRQ
+
+#### Starting GRQ's Elasticsearch cluster
+
+```bash
+# downloading the helm charts from the repository
+helm repo add elastic https://helm.elastic.co
+
+# in the hysds/grq/ directory
+# starting the cluster
+helm install grq-es elastic/elasticsearch --version 7.9.3 -f elasticsearch/values-override.yml
+
+# tearing down the cluster
+helm uninstall grq-es
+```
+
+```bash
+$ curl http://localhost:9201
+# {
+#   "name" : "grq-es-master-0",
+#   "cluster_name" : "grq-es",
+#   "cluster_uuid" : "TWnGGEdKRJaWgkt6p3gtrA",
+#   "version" : {
+#     "number" : "7.9.3",
+#     "build_flavor" : "default",
+#     "build_type" : "docker",
+#     "build_hash" : "c4138e51121ef06a6404866cddc601906fe5c868",
+#     "build_date" : "2020-10-16T10:36:16.141335Z",
+#     "build_snapshot" : false,
+#     "lucene_version" : "8.6.2",
+#     "minimum_wire_compatibility_version" : "6.8.0",
+#     "minimum_index_compatibility_version" : "6.0.0-beta1"
+#   },
+#   "tagline" : "You Know, for Search"
+# }
+```
+
+#### Create the ConfigMap for GRQ's Rest APIs `settings.cfg`
+
+```bash
+# in the hysds/ root directory
+kubectl create configmap grq2-settings --from-file ./grq/rest_api/settings.cfg
+
+# if using Docker desktop
+kubectl.docker create configmap grq2-settings --from-file ./grq/rest_api/settings.cfg
+```
+
+# Factotum
+
+```bash
+$ kubectl.docker create cm datasets --from-file datasets.json
+# configmap/datasets created
+
+$ kubectl.docker create cm supervisord-job-worker --from-file supervisord.conf
+# configmap/supervisord-job-worker created
+```
+
+# All K8 resources
 
 ```bash
 $ kubectl get all
 NAME                           READY   STATUS    RESTARTS   AGE
-pod/celery-tasks               1/1     Running   0          5m57s
-pod/elasticsearch-master-0     1/1     Running   0          74m
-pod/logstash-f6897dbb7-trfcs   1/1     Running   0          14m
-pod/mozart-56f7f5f4b7-kk6qf    1/1     Running   0          27m
-pod/rabbitmq-0                 1/1     Running   0          6m18s
-pod/redis-6f486db698-87858     1/1     Running   0          17m
+pod/celery-tasks               1/1     Running   0          77s
+pod/factotum-job-worker        1/1     Running   0          5s
+pod/grq-es-master-0            1/1     Running   0          74s
+pod/grq2-7b7b749665-8csm9      1/1     Running   0          5s
+pod/logstash-f6897dbb7-qxlkd   1/1     Running   0          77s
+pod/mozart-56f7f5f4b7-nngj9    1/1     Running   0          78s
+pod/mozart-es-master-0         1/1     Running   0          2m24s
+pod/rabbitmq-0                 1/1     Running   0          77s
+pod/redis-6f486db698-h72np     1/1     Running   0          77s
 
 NAME                         TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                         AGE
-service/kubernetes           ClusterIP      10.96.0.1        <none>        443/TCP                         24d
-service/mozart               LoadBalancer   10.107.138.240   localhost     8888:30726/TCP                  27m
-service/mozart-es            LoadBalancer   10.106.93.11     localhost     9200:30534/TCP,9300:30732/TCP   74m
-service/mozart-es-headless   ClusterIP      None             <none>        9200/TCP,9300/TCP               74m
-service/rabbitmq             NodePort       10.98.122.55     <none>        4369:30294/TCP,5672:32741/TCP   6m18s
-service/rabbitmq-mgmt        LoadBalancer   10.109.226.52    localhost     15672:31962/TCP                 6m18s
-service/redis                NodePort       10.108.5.17      <none>        6379:30914/TCP                  17m
+service/grq-es               LoadBalancer   10.107.74.255    localhost     9201:30068/TCP,9301:31307/TCP   74s
+service/grq-es-headless      ClusterIP      None             <none>        9201/TCP,9301/TCP               74s
+service/grq2                 LoadBalancer   10.111.253.126   localhost     8878:31290/TCP                  5s
+service/kubernetes           ClusterIP      10.96.0.1        <none>        443/TCP                         73m
+service/mozart               LoadBalancer   10.106.1.4       localhost     8888:30017/TCP                  78s
+service/mozart-es            LoadBalancer   10.98.13.197     localhost     9200:30578/TCP,9300:31764/TCP   2m24s
+service/mozart-es-headless   ClusterIP      None             <none>        9200/TCP,9300/TCP               2m24s
+service/rabbitmq             NodePort       10.107.111.4     <none>        4369:30444/TCP,5672:30950/TCP   77s
+service/rabbitmq-mgmt        LoadBalancer   10.106.84.161    localhost     15672:31520/TCP                 77s
+service/redis                NodePort       10.111.214.190   <none>        6379:31111/TCP                  77s
 
 NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/logstash   1/1     1            1           14m
-deployment.apps/mozart     1/1     1            1           27m
-deployment.apps/redis      1/1     1            1           17m
+deployment.apps/grq2       1/1     1            1           5s
+deployment.apps/logstash   1/1     1            1           77s
+deployment.apps/mozart     1/1     1            1           78s
+deployment.apps/redis      1/1     1            1           77s
 
 NAME                                 DESIRED   CURRENT   READY   AGE
-replicaset.apps/logstash-f6897dbb7   1         1         1       14m
-replicaset.apps/mozart-56f7f5f4b7    1         1         1       27m
-replicaset.apps/redis-6f486db698     1         1         1       17m
+replicaset.apps/grq2-7b7b749665      1         1         1       5s
+replicaset.apps/logstash-f6897dbb7   1         1         1       77s
+replicaset.apps/mozart-56f7f5f4b7    1         1         1       78s
+replicaset.apps/redis-6f486db698     1         1         1       77s
 
-NAME                                    READY   AGE
-statefulset.apps/elasticsearch-master   1/1     74m
-statefulset.apps/rabbitmq               1/1     6m18s
+NAME                                READY   AGE
+statefulset.apps/grq-es-master      1/1     74s
+statefulset.apps/mozart-es-master   1/1     2m24s
+statefulset.apps/rabbitmq           1/1     77s
 ```
 
 ## Deleting K8 cluster

--- a/hysds/build_images.sh
+++ b/hysds/build_images.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+DIRNAME="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+ARGS=$@
+
+while [ "$1" != "" ]; do
+  case $1 in
+  -f | --file)
+    echo "Can not use the -f/--file flag"
+    exit 1
+    ;;
+  *)
+    ;;
+  esac
+  shift # remove the current value for `$1` and use the next
+done
+
+cd ${DIRNAME}
+docker build . -t hysds-core:unity-v0.0.1 ${ARGS}
+
+cd ${DIRNAME}/mozart/rest_api
+docker build . -t hysds-mozart:unity-v0.0.1 ${ARGS}
+
+cd ${DIRNAME}/mozart/celery
+docker build . -t celery-tasks:unity-v0.0.1 ${ARGS}
+
+cd ${DIRNAME}/grq/rest_api
+docker build . -t hysds-grq2:unity-v0.0.1 ${ARGS}
+
+cd ${DIRNAME}/factotum
+docker build . -t factotum:unity-v0.0.1 ${ARGS}
+
+cd $(pwd)

--- a/hysds/celeryconfig.py
+++ b/hysds/celeryconfig.py
@@ -1,5 +1,5 @@
 broker_url = "amqp://guest:guest@rabbitmq:5672//"
-result_backend = "redis://:redis"
+result_backend = "redis://redis:6379"
 
 task_serializer = "msgpack"
 result_serializer = "msgpack"
@@ -99,7 +99,7 @@ PROCESS_EVENTS_TASKS_QUEUE = "process_events_tasks"
 METRICS_ES_URL = "http://{{ METRICS_ES_PVT_IP }}:9200"
 
 # REDIS_JOB_STATUS_URL = "redis://:{{ MOZART_REDIS_PASSWORD }}@{{ MOZART_REDIS_PVT_IP }}"
-REDIS_JOB_STATUS_URL = "redis://:redis"
+REDIS_JOB_STATUS_URL = "redis://:6379"
 REDIS_JOB_STATUS_KEY = "logstash"
 REDIS_JOB_INFO_URL = "redis://:{{ METRICS_REDIS_PASSWORD }}@{{ METRICS_REDIS_PVT_IP }}"
 REDIS_JOB_INFO_KEY = "logstash"

--- a/hysds/destroy.sh
+++ b/hysds/destroy.sh
@@ -5,6 +5,7 @@ set -e
 command=kubectl
 mozart=0
 grq=0
+factotum=0
 
 docstring() {
   cat << EOF
@@ -31,12 +32,16 @@ while [ "$1" != "" ]; do
   -a | --all)
     mozart=1
     grq=1
+    factotum=1
     ;;
   mozart)
     mozart=1
     ;;
   grq)
     grq=1
+    ;;
+  factotum)
+    factotum=1
     ;;
   *)
     # exit 1
@@ -46,7 +51,7 @@ while [ "$1" != "" ]; do
 done
 
 
-if (($grq==0 && $mozart==0)) ; then
+if (($grq==0 && $mozart==0 && $factotum==0)) ; then
   echo "ERROR: Please specify [mozart|grq|--all] to destroy"
   exit 1
 fi
@@ -54,13 +59,13 @@ fi
 if (($mozart==1)) ; then
   helm uninstall mozart-es || true
 
-  $command delete cm mozart-settings || true
-  $command delete cm logstash-configs || true
   $command delete -f ./mozart/rest_api/deployment.yml || true
   $command delete -f ./mozart/redis/deployment.yml || true
   $command delete -f ./mozart/logstash/deployment.yml || true
   $command delete -f ./mozart/rabbitmq/deployment.yml || true
   $command delete -f ./mozart/celery/deployment.yml || true
+  $command delete cm mozart-settings || true
+  $command delete cm logstash-configs || true
 
   $command get pvc --no-headers=true | awk '/mozart-es/{print $1}' | xargs  kubectl delete pvc || true
 fi
@@ -72,4 +77,11 @@ if (($grq==1)) ; then
   $command delete -f ./grq/rest_api/deployment.yml || true
 
   $command get pvc --no-headers=true | awk '/grq-es/{print $1}' | xargs  kubectl delete pvc || true
+fi
+
+if (($factotum==1)) ; then
+  $command delete -f ./factotum/deployment.yml || true
+
+  $command delete cm datasets || true
+  $command delete cm supervisord-job-worker || true
 fi

--- a/hysds/destroy.sh
+++ b/hysds/destroy.sh
@@ -17,6 +17,7 @@ Usage:
     --all : destroy both Mozart and GRQ cluster
     mozart : destroy mozart cluster
     grq : destroy GRQ cluster
+    factotum : destroy factotum
 EOF
 }
 

--- a/hysds/destroy.sh
+++ b/hysds/destroy.sh
@@ -13,9 +13,9 @@ Usage:
   $0 [--docker] [mozart] [grq] [--all]
   Options:
     --docker : use if running Kubernetes on Docker for Desktop; kubectl vs kubectl.docker
-    --all : deploy both Mozart and GRQ cluster
-    mozart : deploy mozart cluster
-    grq : deploy GRQ cluster
+    --all : destroy both Mozart and GRQ cluster
+    mozart : destroy mozart cluster
+    grq : destroy GRQ cluster
 EOF
 }
 
@@ -47,7 +47,7 @@ done
 
 
 if (($grq==0 && $mozart==0)) ; then
-  echo "ERROR: Please specify [mozart|grq|--all] to deploy"
+  echo "ERROR: Please specify [mozart|grq|--all] to destroy"
   exit 1
 fi
 

--- a/hysds/factotum/Dockerfile
+++ b/hysds/factotum/Dockerfile
@@ -1,0 +1,14 @@
+FROM hysds-core:unity-ol8-v0.0.1
+
+ARG CONTAINERD=containerd.io-1.4.9-3.1.el7.x86_64.rpm
+ARG DOCKERCLI=docker-ce-cli-18.09.0-3.el7.x86_64.rpm
+
+RUN wget -O /tmp/${CONTAINERD} https://download.docker.com/linux/centos/7/x86_64/stable/Packages/${CONTAINERD} && \
+  wget -O /tmp/${DOCKERCLI} https://download.docker.com/linux/centos/7/x86_64/stable/Packages/${DOCKERCLI} && \
+  yum localinstall -y /tmp/${CONTAINERD} && \
+  yum localinstall -y /tmp/${DOCKERCLI} && \
+  pip3 install --no-cache-dir supervisor && \
+  yum clean all && \
+  rm -rf /tmp/*
+
+CMD ["/bin/bash"]

--- a/hysds/factotum/Dockerfile
+++ b/hysds/factotum/Dockerfile
@@ -1,4 +1,4 @@
-FROM hysds-core:unity-ol8-v0.0.1
+FROM hysds-core:unity-v0.0.1
 
 ARG CONTAINERD=containerd.io-1.4.9-3.1.el7.x86_64.rpm
 ARG DOCKERCLI=docker-ce-cli-18.09.0-3.el7.x86_64.rpm

--- a/hysds/factotum/datasets.json
+++ b/hysds/factotum/datasets.json
@@ -1,0 +1,52 @@
+{
+  "datasets": [
+    {
+      "ipath": "ariamh::data/area_of_interest",
+      "match_pattern": "/(?P<id>AOI_.+)$",
+      "alt_match_pattern": null,
+      "extractor": null,
+      "level": "L0",
+      "type": "area_of_interest",
+      "publish": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ LTS_BUCKET }}/products/{id}",
+        "urls": [
+          "http://{{ LTS_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/products/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ LTS_BUCKET }}/products/{id}"
+        ]
+      },
+      "browse": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ LTS_BUCKET }}/browse/{id}",
+        "urls": [
+          "http://{{ LTS_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/browse/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ LTS_BUCKET }}/browse/{id}"
+        ]
+      }
+    },
+    {
+      "ipath": "hysds::data/hello_world",
+      "level": "NA",
+      "type": "hello_world",
+      "match_pattern": "/(?P<id>hello_world-product-(?P<year>\\d{4})(?P<month>\\d{2})(?P<day>\\d{2})T.*)$",
+      "alt_match_pattern": null,
+      "extractor": null,
+      "publish": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ LTS_BUCKET }}/products/hello_world/{version}/{year}/{month}/{day}/{id}",
+        "urls": [
+          "http://{{ LTS_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/products/hello_world/{version}/{year}/{month}/{day}/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ LTS_BUCKET }}/products/hello_world/{version}/{year}/{month}/{day}/{id}"
+        ]
+      },
+      "browse": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ LTS_BUCKET }}/browse/hello_world/{version}/{year}/{month}/{day}/{id}",
+        "urls": [
+          "http://{{ LTS_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/browse/hello_world/{version}/{year}/{month}/{day}/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ LTS_BUCKET }}/browse/hello_world/{version}/{year}/{month}/{day}/{id}"
+        ]
+      }
+    }
+  ]
+}

--- a/hysds/factotum/deployment.yml
+++ b/hysds/factotum/deployment.yml
@@ -4,11 +4,9 @@ metadata:
   name: factotum-job-worker
 spec:
   containers:
-    - name: docker-cmds
-      # image: docker:1.12.6
-      # command: ["docker", "run", "-p", "80:80", "httpd:latest"]
+    - name: factotum-job-worker
       image: factotum:unity-v0.0.1
-      command: ["/usr/bin/supervisord", "--nodaemon"]
+      command: ["supervisord", "--nodaemon"]
       resources:
         requests:
           cpu: 500m
@@ -19,6 +17,12 @@ spec:
         - name: celeryconfig
           mountPath: /root/hysds/celeryconfig.py
           subPath: celeryconfig.py
+        - name: datasets
+          mountPath: /root/datasets.json
+          subPath: datasets.json
+        - name: supervisord-job-worker
+          mountPath: /root/supervisord.conf
+          subPath: supervisord.conf
   volumes:
     - name: docker-sock
       hostPath:
@@ -26,3 +30,9 @@ spec:
     - name: celeryconfig
       configMap:
         name: celeryconfig
+    - name: datasets
+      configMap:
+        name: datasets
+    - name: supervisord-job-worker
+      configMap:
+        name: supervisord-job-worker

--- a/hysds/factotum/deployment.yml
+++ b/hysds/factotum/deployment.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: factotum-job-worker
+spec:
+  containers:
+    - name: docker-cmds
+      # image: docker:1.12.6
+      # command: ["docker", "run", "-p", "80:80", "httpd:latest"]
+      image: factotum:unity-v0.0.1
+      command: ["/usr/bin/supervisord", "--nodaemon"]
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+      volumeMounts:
+        - name: docker-sock
+          mountPath: /var/run/docker.sock
+        - name: celeryconfig
+          mountPath: /root/hysds/celeryconfig.py
+          subPath: celeryconfig.py
+  volumes:
+    - name: docker-sock
+      hostPath:
+        path: /var/run/docker.sock
+    - name: celeryconfig
+      configMap:
+        name: celeryconfig

--- a/hysds/factotum/supervisord.conf
+++ b/hysds/factotum/supervisord.conf
@@ -1,0 +1,31 @@
+[supervisord]
+
+[program:factotum-job_worker-small]
+directory=/root/hysds
+environment=HYSDS_ROOT_WORK_DIR="/data/work",
+            HYSDS_DATASETS_CFG="/root/datasets.json"
+command=celery --app=hysds worker --concurrency=1 --loglevel=INFO -Q factotum-job_worker-small -n %(program_name)s.%(process_num)02d.%%h -O fair --without-mingle --without-gossip --heartbeat-interval=60
+process_name=%(program_name)s-%(process_num)02d
+priority=1
+numprocs=1
+numprocs_start=0
+redirect_stderr=true
+stdout_logfile=/root/%(program_name)s-%(process_num)02d.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=10
+startsecs=10
+
+[program:factotum-job_worker-large]
+directory=/root/hysds
+environment=HYSDS_ROOT_WORK_DIR="/data/work",
+            HYSDS_DATASETS_CFG="/root/datasets.json"
+command=celery --app=hysds worker --concurrency=1 --loglevel=INFO -Q factotum-job_worker-large -n %(program_name)s.%(process_num)02d.%%h -O fair --without-mingle --without-gossip --heartbeat-interval=60
+process_name=%(program_name)s-%(process_num)02d
+priority=1
+numprocs=1
+numprocs_start=0
+redirect_stderr=true
+stdout_logfile=/root/%(program_name)s-%(process_num)02d.log
+stdout_logfile_maxbytes=100MB
+stdout_logfile_backups=10
+startsecs=10

--- a/hysds/grq/rest_api/deployment.yml
+++ b/hysds/grq/rest_api/deployment.yml
@@ -33,9 +33,6 @@ spec:
       containers:
         - name: grq2
           image: hysds-grq2:unity-v0.0.1
-          # env:
-          #   - name: WORKERS
-          #     value: "4"
           ports:
             - containerPort: 8878
               name: grq2


### PR DESCRIPTION
- fixed redis endpoint in `celeryconfig.py`
- added `Dockerfile` for factotum docker image
- added `sueprvisord.conf` & `datasets.json` to factotum 
- re-organized `README.md`
- added factotum to `deploy.sh` & `destroy.sh`
- added `build_images.sh` script to build all docker images

TODO:
- find a way to replicate [container-builder](https://github.com/hysds/container-builder) to build PGEs locally (docker images, etc.) and register job into Elasticsearch (mozart or GRQ)

using this [article](https://applatix.com/case-docker-docker-kubernetes-part-2/) as reference was able to run a watered-down `factotum` in a pod
by mounting `/var/run/docker.sock` into the pod we are able to use docker, and ultimately be able to run PGEs locally

```bash
$ kubectl.docker exec -it pod/factotum-job-worker -- bash
[root@factotum-job-worker ~]# docker images
REPOSITORY                                      TAG                                                     IMAGE ID            CREATED             SIZE
factotum                                        unity-v0.0.1                                            4b1c954d036c        19 hours ago        1.58GB
hysds-grq2                                      unity-v0.0.1                                            7b5b470b5fde        3 weeks ago         1.1GB
hysds-core                                      unity-ol8-v0.0.1                                        a90fe737d6ff        3 weeks ago         1.29GB
hysds-mozart                                    unity-v0.0.1                                            948e780f4d07        3 weeks ago         1.06GB
hysds-core                                      unity-v0.0.1                                            15519aa6c54a        3 weeks ago         951MB
celery-tasks                                    unity-v0.0.1                                            505154e59068        3 weeks ago         197MB
hysds/pge-base                                  develop                                                 14b8c34341f0        3 weeks ago         3.19GB
.
.
.
[root@factotum-job-worker ~]# cat factotum-job_worker-small-00.log 
/root/miniconda3/lib/python3.9/site-packages/celery/platforms.py:840: SecurityWarning: You're running the worker with superuser privileges: this is
absolutely not recommended!

Please specify a different user using the --uid option.

User information: uid=0 euid=0 gid=0 egid=0

  warnings.warn(SecurityWarning(ROOT_DISCOURAGED.format(
 
 -------------- celery@factotum-job_worker-small.00.factotum-job-worker v5.2.2 (dawn-chorus)
--- ***** ----- 
-- ******* ---- Linux-5.10.25-linuxkit-x86_64-with-glibc2.28 2022-01-26 23:52:39
- *** --- * --- 
- ** ---------- [config]
- ** ---------- .> app:         hysds:0x7f0b794c6280
- ** ---------- .> transport:   amqp://guest:**@rabbitmq:5672//
- ** ---------- .> results:     redis://redis:6379/
- *** --- * --- .> concurrency: 1 (prefork)
-- ******* ---- .> task events: ON
--- ***** ----- 
 -------------- [queues]
                .> factotum-job_worker-small exchange=factotum-job_worker-small(direct) key=factotum-job_worker-small
                

[tasks]
  . hysds.job_worker.run_job
  . hysds.orchestrator.submit_job
  . hysds.task_worker.run_task
  . hysds.utils.error_handler

[2022-01-26 23:52:39,554: INFO/MainProcess] Connected to amqp://guest:**@rabbitmq:5672//
[2022-01-26 23:52:39,592: INFO/MainProcess] celery@factotum-job_worker-small.00.factotum-job-worker ready.
```

`factotum` job worker queues in RabbitMQ
<img width="750" alt="Screen Shot 2022-01-26 at 4 07 07 PM" src="https://user-images.githubusercontent.com/13371881/151267988-2ad0418a-538c-41ac-9839-ae128be46376.png">

