### PR TITLE
fixed minio setup to ping minio:9000 before proceeding

### DIFF
--- a/hysds/minio/deployment.yml
+++ b/hysds/minio/deployment.yml
@@ -32,8 +32,8 @@ spec:
         app: minio
     spec:
       containers:
-        - image: "minio/minio:latest"
-          name: minio
+        - name: minio
+          image: minio/minio:RELEASE.2022-03-17T06-34-49Z
           args:
             - server
             - /storage

--- a/hysds/minio/post-setup.yml
+++ b/hysds/minio/post-setup.yml
@@ -5,19 +5,8 @@ metadata:
 spec:
   restartPolicy: Never
   initContainers:
-    - name: ping-minio-server
-      image: k8s.gcr.io/busybox
-      command: ["/bin/sh", "-c"]
-      args:
-        - /bin/sh
-        - -c
-        - >
-          set -x;
-          while [ $(curl -sw '%{http_code}' "http://minio:9001" -o /dev/null) -ne 200 ]; do
-            sleep 5;
-          done
     - name: minio-setup
-      image: minio/mc
+      image: minio/mc:RELEASE.2022-03-13T22-34-00Z
       env:
         - name: MINIO_ACCESS_KEY
           value: hysds
@@ -25,7 +14,9 @@ spec:
           value: password
       command: ["/bin/sh", "-c"]
       args:
-        - mc alias set s3 http://minio:9000 ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY};
+        - until curl -s -I http://minio:9000; do echo "(Minio server) waiting..."; sleep 2; done;
+          until curl -s -I http://minio:9001; do echo "(Minio client) waiting..."; sleep 2; done;
+          mc alias set s3 http://minio:9000 ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY};
           mc mb s3/datasets;
           mc policy set public s3/datasets;
   containers:


### PR DESCRIPTION
found the bug with `mino` which occurred during our demo

`mc` was unable to initialize the `dataset` bucket because the minio:9000 server was not started
added a `wait... until` in the the `minio-setup` `initContainer` to wait for the minio server first

@Drew ran into this issue yesterday but for some reason didn't happen on my cluster until today

also locking the docker image tags for `minio/minio` and `minio/mc`

new logs from the `initContainer`:
```bash
kubectl logs -f pod/mc -c minio-setup                                           
(Minio server) waiting...
(Minio server) waiting...
HTTP/1.1 400 Bad Request
Accept-Ranges: bytes
Content-Length: 261
Content-Type: application/xml
Server: MinIO
Vary: Origin
Date: Wed, 06 Apr 2022 23:37:05 GMT

HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 1266
Content-Type: text/html
Last-Modified: Wed, 06 Apr 2022 23:37:05 GMT
Server: MinIO Console
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Xss-Protection: 1; mode=block
Date: Wed, 06 Apr 2022 23:37:05 GMT
Connection: close

Added `s3` successfully.
Bucket created successfully `s3/datasets`.
Access permission for `s3/datasets` is set to `public`
```