### PR TITLE
HySDS uses a new method of publushing datasets

### DIFF
--- a/hysds/configs/celeryconfig_local.py
+++ b/hysds/configs/celeryconfig_local.py
@@ -68,6 +68,7 @@ TOSCA_URL = "https://{{ GRQ_PVT_IP }}/search/"
 GRQ_URL = "http://grq2:8878"
 GRQ_REST_URL = "http://grq2:8878/api/v0.1"
 GRQ_UPDATE_URL = "http://grq2:8878/api/v0.1/grq/dataset/index"
+GRQ_UPDATE_URL_BULK = "http://grq2:8878/api/v0.2/grq/dataset/index"
 
 
 GRQ_AWS_ES = False

--- a/hysds/configs/celeryconfig_remote.py
+++ b/hysds/configs/celeryconfig_remote.py
@@ -68,6 +68,7 @@ TOSCA_URL = "https://{{ GRQ_PVT_IP }}/search/"
 GRQ_URL = "http://grq2:8878"
 GRQ_REST_URL = "http://grq2:8878/api/v0.1"
 GRQ_UPDATE_URL = "http://grq2:8878/api/v0.1/grq/dataset/index"
+GRQ_UPDATE_URL_BULK = "http://grq2:8878/api/v0.2/grq/dataset/index"
 
 
 GRQ_AWS_ES = False


### PR DESCRIPTION
related PR(s):
- https://github.com/hysds/hysds/pull/140
- https://github.com/hysds/grq2/pull/51

related HySDS core ticket: https://hysds-core.atlassian.net/browse/HC-376

## Purpose
HySDS uses a new method of publishing datasets, using the ES bulk API and does proper rollback when publishing fails
it uses v2 of the grq2 dataset index endpoint so it needs to be configured in `celeryconfig.py`

## Proposed Changes
- [CHANGE] added `GRQ_UPDATE_URL_BULK = "http://grq2:8878/api/v0.2/grq/dataset/index"` to `celeryconfig.py`
## Issues
- https://hysds-core.atlassian.net/browse/HC-376
## Testing
tested it on NISAR in our dev-e2e test