### PR TITLE
add sps-api docker image to terraform-unity variables

### DIFF
--- a/terraform-unity/variables.tf
+++ b/terraform-unity/variables.tf
@@ -34,6 +34,7 @@ variable "docker_images" {
     hysds_verdi    = "ghcr.io/unity-sds/unity-sps-prototype/hysds-verdi:unity-v0.0.1"
     hysds_factotum = "ghcr.io/unity-sds/unity-sps-prototype/hysds-factotum:unity-v0.0.1"
     ades_wpst_api  = "ghcr.io/unity-sds/unity-sps-prototype/ades-wpst-api:unity-v0.0.1"
+    sps_api        = "ghcr.io/unity-sds/unity-sps-prototype/sps-api:unity-v0.0.1"
     logstash       = "docker.elastic.co/logstash/logstash:7.10.2"
     rabbitmq       = "rabbitmq:3-management"
     busybox        = "k8s.gcr.io/busybox"


### PR DESCRIPTION
## Purpose
- Hotfix needed to resolve failing automatic deployments
## Proposed Changes
- [ADD] sps_api to docker image map in `terraform-unity/variables.tf`
