### PR TITLE
#167 Fix deploy process timeout

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -15,7 +15,7 @@ env:
   ADES_WPST_API_DEPLOY_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-deploy
   ADES_WPST_API_FORK_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-fork
   SPS_API_IMAGE_NAME: ${{ github.repository }}/sps-api
-  SPS_HYSDS_PGE_BASE_IMAGE: ${{ githuib.repository }}/sps-hysds-pge-base
+  SPS_HYSDS_PGE_BASE_IMAGE_NAME: ${{ github.repository }}/sps-hysds-pge-base
 
 on: workflow_dispatch
 

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -15,6 +15,7 @@ env:
   ADES_WPST_API_DEPLOY_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-deploy
   ADES_WPST_API_FORK_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-fork
   SPS_API_IMAGE_NAME: ${{ github.repository }}/sps-api
+  SPS_HYSDS_PGE_BASE_IMAGE: ${{ githuib.repository }}/sps-hysds-pge-base
 
 on: workflow_dispatch
 
@@ -300,4 +301,31 @@ jobs:
           file: docker/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.SPS_API_IMAGE_NAME }}:${{ env.TAG }}
+          labels: ${{ steps.metasps.outputs.labels }}
+
+  build-sps-hysds-pge-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: unity-sds/unity-sps-register_job
+      - name: Log in to the container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for SPS HySDS base PGE Docker image
+        id: metasps
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.SPS_API_IMAGE_NAME }}
+      - name: Build and push SPS HySDS base PGE Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: docker/Dockerfile_sps-hysds-pge-base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.SPS_HYSDS_PGE_BASE_IMAGE_NAME }}:${{ env.TAG }}
           labels: ${{ steps.metasps.outputs.labels }}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -227,7 +227,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: unity-sds/ades_wpst
-          ref: 167-build-timeout-fix
+          ref: deploy
       - name: Log in to the container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -227,7 +227,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: unity-sds/ades_wpst
-          ref: deploy
+          ref: 167-build-timeout-fix
       - name: Log in to the container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:

--- a/terraform-modules/terraform-unity-sps-hysds-cluster/ades_wpst.tf
+++ b/terraform-modules/terraform-unity-sps-hysds-cluster/ades_wpst.tf
@@ -110,7 +110,8 @@ resource "kubernetes_deployment" "ades-wpst-api" {
                 command = [
                   "bin/sh",
                   "-c",
-                  "sleep 5; chmod 777 /var/run/docker.sock"
+                  "sleep 5; chmod 777 /var/run/docker.sock",
+                  "docker pull ghcr.io/unity-sds/sps-hysds-pge-base:unity-v0.0.1"
                 ]
               }
             }


### PR DESCRIPTION
## Purpose
- fix timeout in process deployments caused by slow docker image builds
## Proposed Changes
- [ADD] docker image that already includes needed python libraries
- [ADD] `docker pull` during deployment of wpst to save image download time on process deployment
## Issues
- #167
## Testing
- Tested with requests from my machine demonstrating process deployment takes ~50s reduced from >100s
- Tested with smoke test github action runs

## Other
PR is dependent on two other PR's:
-[ change in Unity job image repo TEST ](https://github.com/unity-sds/unity-sps-register_job/pull/4)
-[ change in Unity job image repo DEV ](https://github.com/unity-sds/unity-sps-register_job/pull/5)