### PR TITLE
fix bug in deployment pull of hysds pge base image

### DIFF
--- a/terraform-modules/terraform-unity-sps-hysds-cluster/ades_wpst.tf
+++ b/terraform-modules/terraform-unity-sps-hysds-cluster/ades_wpst.tf
@@ -110,8 +110,7 @@ resource "kubernetes_deployment" "ades-wpst-api" {
                 command = [
                   "bin/sh",
                   "-c",
-                  "sleep 5; chmod 777 /var/run/docker.sock",
-                  "docker pull ghcr.io/unity-sds/sps-hysds-pge-base:unity-v0.0.1"
+                  "sleep 5; chmod 777 /var/run/docker.sock; docker pull ghcr.io/unity-sds/unity-sps-prototype/sps-hysds-pge-base:unity-v0.0.1"
                 ]
               }
             }


### PR DESCRIPTION
## Purpose
- Previous change to pull hysds base images didn't pull image correctly. This change fixes that, further speeding up process deployments with hysds backends.
## Proposed Changes
- [FIX] post-start exec hook in dind-daemon container of ades-wpst-api kuberenetes deployment
## Issues
- #167 
## Testing
- Successful image pull verified with `docker image ls` in deployed container.
