### PR TITLE
Hot-fix: Add backoff/retry when requesting job status by id

### DIFF
--- a/unity-test/step_defs/test_get_processing_status.py
+++ b/unity-test/step_defs/test_get_processing_status.py
@@ -1,4 +1,6 @@
-from pytest_bdd import scenario, given, when, then, parsers
+from pytest_bdd import scenario, given, when, then
+import backoff
+import requests
 
 from .conftest import FEATURES_DIR, _request_job_status_by_id
 
@@ -22,6 +24,13 @@ def created_response(response):
 @when(
     "a WPS-T request is made to get the status of the job by its ID",
     target_fixture="response",
+)
+@backoff.on_exception(
+    backoff.constant,
+    (requests.exceptions.HTTPError),
+    max_time=3600,
+    jitter=None,
+    interval=1,
 )
 def request_job_status_by_id(process_service_endpoint, project_process_dict, job_id):
     return _request_job_status_by_id(


### PR DESCRIPTION
## Purpose
- This PR adds a backoff/retry to our regression tests when requesting job status by ID.
- This is required because it appears there is an existing issue with the WPS-T API.
  - The issue is that when a request to execute a process is made, the response includes a 201 status code along with the job ID, however, if a request to get the job status is made immediately after the response is received, a 500 status code is returned. There appears to latency between when a job is said to have been accepted and when it is actually registered by the WPS-T.

## Proposed Changes
- Add backoff/retry when requesting job status by id

## Issues
- N/A

## Testing

[![U-SPS Regression Test](https://github.com/unity-sds/unity-sps-prototype/actions/workflows/regression_test.yml/badge.svg?branch=171-scale-worker-nodes)](https://github.com/unity-sds/unity-sps-prototype/actions/workflows/regression_test.yml)
