### PR TITLE
Update Regression Test to Support Updates to CHIRP Re-binning Workflow

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -18,10 +18,6 @@ env:
   REMOTE_UI_IMAGE_NAME: ${{ github.repository }}/hysds-ui-remote
   REMOTE_UI_AUTH_IMAGE_NAME: ${{ github.repository }}/hysds-ui-remote-auth
   ADES_WPST_API_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api
-
-  # ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-mcp-dev-tmp
-  # ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-mcp-test-tmp
-
   SPS_API_IMAGE_NAME: ${{ github.repository }}/sps-api
   SPS_HYSDS_PGE_BASE_IMAGE_NAME: ${{ github.repository }}/sps-hysds-pge-base
 
@@ -201,62 +197,6 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_IMAGE_NAME }}:${{ env.TAG }}
           labels: ${{ steps.metaades.outputs.labels }}
-
-  # build-ades-wpst-api-mcp-dev-tmp:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: unity-sds/ades_wpst
-  #         ref: MCP_DEV_TMP
-  #     - name: Log in to the container registry
-  #       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-  #       with:
-  #         registry: ${{ env.REGISTRY }}
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Extract metadata (tags, labels) for ADES WPST API MCP Dev Tmp Docker image
-  #       id: metaades
-  #       uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-  #       with:
-  #         images: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME }}
-  #     - name: Build and push ADES WPST API MCP Dev Tmp Docker image
-  #       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-  #       with:
-  #         context: .
-  #         file: docker/Dockerfile
-  #         push: true
-  #         tags: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME }}:${{ env.TAG }}
-  #         labels: ${{ steps.metaades.outputs.labels }}
-
-  # build-ades-wpst-api-mcp-test-tmp:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: unity-sds/ades_wpst
-  #         ref: MCP_TEST_TMP
-  #     - name: Log in to the container registry
-  #       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-  #       with:
-  #         registry: ${{ env.REGISTRY }}
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Extract metadata (tags, labels) for ADES WPST API MCP Test Tmp Docker image
-  #       id: metaades
-  #       uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-  #       with:
-  #         images: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME }}
-  #     - name: Build and push ADES WPST API MCP Test Tmp Docker image
-  #       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-  #       with:
-  #         context: .
-  #         file: docker/Dockerfile
-  #         push: true
-  #         tags: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME }}:${{ env.TAG }}
-  #         labels: ${{ steps.metaades.outputs.labels }}
 
   build-sps-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -19,11 +19,12 @@ env:
   REMOTE_UI_AUTH_IMAGE_NAME: ${{ github.repository }}/hysds-ui-remote-auth
   ADES_WPST_API_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api
 
-  ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-mcp-dev-tmp
-  ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-mcp-test-tmp
+  # ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-mcp-dev-tmp
+  # ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME: ${{ github.repository }}/ades-wpst-api-mcp-test-tmp
 
   SPS_API_IMAGE_NAME: ${{ github.repository }}/sps-api
   SPS_HYSDS_PGE_BASE_IMAGE_NAME: ${{ github.repository }}/sps-hysds-pge-base
+  SPS_HYSDS_PGE_BASE_DEVELOP_IMAGE_NAME: ${{ github.repository }}/sps-hysds-pge-base-develop
 
 jobs:
   build-hysds-core:
@@ -202,61 +203,61 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_IMAGE_NAME }}:${{ env.TAG }}
           labels: ${{ steps.metaades.outputs.labels }}
 
-  build-ades-wpst-api-mcp-dev-tmp:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          repository: unity-sds/ades_wpst
-          ref: MCP_DEV_TMP
-      - name: Log in to the container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for ADES WPST API MCP Dev Tmp Docker image
-        id: metaades
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME }}
-      - name: Build and push ADES WPST API MCP Dev Tmp Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          file: docker/Dockerfile
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME }}:${{ env.TAG }}
-          labels: ${{ steps.metaades.outputs.labels }}
+  # build-ades-wpst-api-mcp-dev-tmp:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: unity-sds/ades_wpst
+  #         ref: MCP_DEV_TMP
+  #     - name: Log in to the container registry
+  #       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Extract metadata (tags, labels) for ADES WPST API MCP Dev Tmp Docker image
+  #       id: metaades
+  #       uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+  #       with:
+  #         images: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME }}
+  #     - name: Build and push ADES WPST API MCP Dev Tmp Docker image
+  #       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+  #       with:
+  #         context: .
+  #         file: docker/Dockerfile
+  #         push: true
+  #         tags: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_DEV_TMP_IMAGE_NAME }}:${{ env.TAG }}
+  #         labels: ${{ steps.metaades.outputs.labels }}
 
-  build-ades-wpst-api-mcp-test-tmp:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          repository: unity-sds/ades_wpst
-          ref: MCP_TEST_TMP
-      - name: Log in to the container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for ADES WPST API MCP Test Tmp Docker image
-        id: metaades
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME }}
-      - name: Build and push ADES WPST API MCP Test Tmp Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          file: docker/Dockerfile
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME }}:${{ env.TAG }}
-          labels: ${{ steps.metaades.outputs.labels }}
+  # build-ades-wpst-api-mcp-test-tmp:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: unity-sds/ades_wpst
+  #         ref: MCP_TEST_TMP
+  #     - name: Log in to the container registry
+  #       uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Extract metadata (tags, labels) for ADES WPST API MCP Test Tmp Docker image
+  #       id: metaades
+  #       uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+  #       with:
+  #         images: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME }}
+  #     - name: Build and push ADES WPST API MCP Test Tmp Docker image
+  #       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+  #       with:
+  #         context: .
+  #         file: docker/Dockerfile
+  #         push: true
+  #         tags: ${{ env.REGISTRY }}/${{ env.ADES_WPST_API_MCP_TEST_TMP_IMAGE_NAME }}:${{ env.TAG }}
+  #         labels: ${{ steps.metaades.outputs.labels }}
 
   build-sps-api:
     runs-on: ubuntu-latest
@@ -302,7 +303,7 @@ jobs:
         id: metasps
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.SPS_API_IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.SPS_HYSDS_PGE_BASE_IMAGE_NAME }}
       - name: Build and push SPS HySDS base PGE Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
@@ -310,4 +311,32 @@ jobs:
           file: docker/Dockerfile_sps-hysds-pge-base
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.SPS_HYSDS_PGE_BASE_IMAGE_NAME }}:${{ env.TAG }}
+          labels: ${{ steps.metasps.outputs.labels }}
+
+  build-sps-hysds-pge-base-develop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: unity-sds/unity-sps-register_job
+          ref: develop
+      - name: Log in to the container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for SPS HySDS base PGE Docker image
+        id: metasps
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.SPS_HYSDS_PGE_BASE_DEVELOP_IMAGE_NAME }}
+      - name: Build and push SPS HySDS base PGE Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: docker/Dockerfile_sps-hysds-pge-base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.SPS_HYSDS_PGE_BASE_DEVELOP_IMAGE_NAME }}:${{ env.TAG }}
           labels: ${{ steps.metasps.outputs.labels }}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -24,7 +24,6 @@ env:
 
   SPS_API_IMAGE_NAME: ${{ github.repository }}/sps-api
   SPS_HYSDS_PGE_BASE_IMAGE_NAME: ${{ github.repository }}/sps-hysds-pge-base
-  SPS_HYSDS_PGE_BASE_DEVELOP_IMAGE_NAME: ${{ github.repository }}/sps-hysds-pge-base-develop
 
 jobs:
   build-hysds-core:
@@ -311,32 +310,4 @@ jobs:
           file: docker/Dockerfile_sps-hysds-pge-base
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.SPS_HYSDS_PGE_BASE_IMAGE_NAME }}:${{ env.TAG }}
-          labels: ${{ steps.metasps.outputs.labels }}
-
-  build-sps-hysds-pge-base-develop:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          repository: unity-sds/unity-sps-register_job
-          ref: develop
-      - name: Log in to the container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for SPS HySDS base PGE Docker image
-        id: metasps
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.SPS_HYSDS_PGE_BASE_DEVELOP_IMAGE_NAME }}
-      - name: Build and push SPS HySDS base PGE Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          file: docker/Dockerfile_sps-hysds-pge-base
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.SPS_HYSDS_PGE_BASE_DEVELOP_IMAGE_NAME }}:${{ env.TAG }}
           labels: ${{ steps.metasps.outputs.labels }}

--- a/terraform-modules/terraform-unity-sps-hysds-cluster/variables.tf
+++ b/terraform-modules/terraform-unity-sps-hysds-cluster/variables.tf
@@ -60,7 +60,7 @@ variable "docker_images" {
     hysds_factotum     = "ghcr.io/unity-sds/unity-sps-prototype/hysds-factotum:unity-v1.0.0"
     ades_wpst_api      = "ghcr.io/unity-sds/unity-sps-prototype/ades-wpst-api:unity-v1.0.0"
     sps_api            = "ghcr.io/unity-sds/unity-sps-prototype/sps-api:unity-v1.0.0"
-    sps_hysds_pge_base = "ghcr.io/unity-sds/unity-sps-prototype/sps-hysds-pge-base:unity-v1.0.0"
+    sps_hysds_pge_base = "ghcr.io/unity-sds/unity-sps-prototype/sps-hysds-pge-base:develop"
     logstash           = "docker.elastic.co/logstash/logstash:7.10.2"
     rabbitmq           = "rabbitmq:3.11.13-management"
     busybox            = "busybox:1.36.0"

--- a/terraform-unity/variables.tf
+++ b/terraform-unity/variables.tf
@@ -60,7 +60,7 @@ variable "docker_images" {
     hysds_factotum     = "ghcr.io/unity-sds/unity-sps-prototype/hysds-factotum:unity-v1.0.0"
     ades_wpst_api      = "ghcr.io/unity-sds/unity-sps-prototype/ades-wpst-api:unity-v1.0.0"
     sps_api            = "ghcr.io/unity-sds/unity-sps-prototype/sps-api:unity-v1.0.0"
-    sps_hysds_pge_base = "ghcr.io/unity-sds/unity-sps-prototype/sps-hysds-pge-base:unity-v1.0.0"
+    sps_hysds_pge_base = "ghcr.io/unity-sds/unity-sps-prototype/sps-hysds-pge-base:develop"
     logstash           = "docker.elastic.co/logstash/logstash:7.10.2"
     rabbitmq           = "rabbitmq:3.11.13-management"
     busybox            = "busybox:1.36.0"

--- a/unity-test/data/sounder_sips/chirp/deploy_post_request_body.json
+++ b/unity-test/data/sounder_sips/chirp/deploy_post_request_body.json
@@ -7,13 +7,23 @@
         "offering": {
           "code": "http://www.opengis.net/eoc/applicationContext/cwl",
           "content": {
-            "href": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/sounder_sips/chirp/chirp-rebinning-e2e-workflow.cwl"
+            "href": "https://raw.githubusercontent.com/drewm-jpl/sounder-sips-chirp-workflows/main/chirp-rebinning-e2e-workflow.cwl"
           }
         }
       },
       "abstract": "chirp",
       "keywords": [],
       "inputs": [
+        {
+          "id": "input_processing_labels",
+          "title": "input_processing_labels",
+          "formats": [
+            {
+              "mimeType": "text",
+              "default": true
+            }
+          ]
+        },
         {
           "id": "input_cmr_collection_name",
           "title": "input_cmr_collection_name",
@@ -45,8 +55,8 @@
           ]
         },
         {
-          "id": "input_cmr_edl_user",
-          "title": "input_cmr_edl_user",
+          "id": "output_collection_id",
+          "title": "output_collection_id",
           "formats": [
             {
               "mimeType": "text",
@@ -55,8 +65,28 @@
           ]
         },
         {
-          "id": "input_cmr_edl_pass",
-          "title": "input_cmr_edl_pass",
+          "id": "output_data_bucket",
+          "title": "output_data_bucket",
+          "formats": [
+            {
+              "mimeType": "text",
+              "default": true
+            }
+          ]
+        },
+        {
+          "id": "input_daac_collection_shortname",
+          "title": "input_daac_collection_shortname",
+          "formats": [
+            {
+              "mimeType": "text",
+              "default": true
+            }
+          ]
+        },
+        {
+          "id": "input_daac_collection_sns",
+          "title": "input_daac_collection_sns",
           "formats": [
             {
               "mimeType": "text",
@@ -65,18 +95,7 @@
           ]
         }
       ],
-      "outputs": [
-        {
-          "id": "products",
-          "title": "CHIRP Rebinned Products",
-          "formats": [
-            {
-              "mimeType": "text/plain",
-              "default": true
-            }
-          ]
-        }
-      ]
+      "outputs": []
     },
     "processVersion": "develop",
     "jobControlOptions": ["async-execute"],

--- a/unity-test/data/sounder_sips/chirp/deploy_post_request_body.json
+++ b/unity-test/data/sounder_sips/chirp/deploy_post_request_body.json
@@ -7,7 +7,7 @@
         "offering": {
           "code": "http://www.opengis.net/eoc/applicationContext/cwl",
           "content": {
-            "href": "https://raw.githubusercontent.com/drewm-jpl/sounder-sips-chirp-workflows/main/chirp-rebinning-e2e-workflow.cwl"
+            "href": "https://raw.githubusercontent.com/unity-sds/sounder-sips-chirp-workflows/main/chirp-rebinning-e2e-workflow.cwl"
           }
         }
       },

--- a/unity-test/data/sounder_sips/chirp/execution_post_request_body.json
+++ b/unity-test/data/sounder_sips/chirp/execution_post_request_body.json
@@ -4,7 +4,7 @@
   "inputs": [
     {
       "id": "input_processing_labels",
-      "data": ["lable1", "label2"]
+      "data": ["label1", "label2"]
     },
     {
       "id": "input_cmr_collection_name",

--- a/unity-test/data/sounder_sips/chirp/execution_post_request_body.json
+++ b/unity-test/data/sounder_sips/chirp/execution_post_request_body.json
@@ -3,24 +3,36 @@
   "response": "document",
   "inputs": [
     {
+      "id": "input_processing_labels",
+      "data": ["lable1", "label2"]
+    },
+    {
       "id": "input_cmr_collection_name",
-      "data": "my_input_coll"
+      "data": "C2011289787-GES_DISC"
     },
     {
       "id": "input_cmr_search_start_time",
-      "data": "2023-01-01"
+      "data": "2016-08-22T00:10:00Z"
     },
     {
       "id": "input_cmr_search_stop_time",
-      "data": "2023-01-31"
+      "data": "2016-09-06T23:59:59Z"
     },
     {
-      "id": "input_cmr_edl_user",
-      "data": "abc"
+      "id": "output_collection_id",
+      "data": "CHIRP_OUTPUT_COLLECTION"
     },
     {
-      "id": "input_cmr_edl_pass",
-      "data": "def"
+      "id": "output_data_bucket",
+      "data": "s3://unity-data-bucket"
+    },
+    {
+      "id": "input_daac_collection_shortname",
+      "data": "CHIRP_L1B"
+    },
+    {
+      "id": "input_daac_collection_sns",
+      "data": "arn:://SNS-arn"
     }
   ],
   "outputs": [


### PR DESCRIPTION
## Purpose

- The purpose of this PR is to update the regression test to support updates to CHIRP re-binning workflow.

## Proposed Changes

- Change the CHIRP re-binning request bodies used in the regression test for deploying and executing the process.

## Issues

- Gets us closer to resolving https://github.com/unity-sds/unity-sps-workflows/issues/9#issue-1669859270

## Testing

- Regression Tests:
  - [MCP Test](https://github.com/unity-sds/unity-sps-prototype/actions/runs/4823951663)
  - [MCP Dev](https://github.com/unity-sds/unity-sps-prototype/actions/runs/4823916288)


## Housekeeping Updates

- Update the image builder workflow/GH action to remove images which are no longer needed.

## Related Changes in Other Repos
- https://github.com/unity-sds/unity-sps-register_job/pull/6
- Use a temporary `develop` tag for the `sps-hysds-pge-base` image in the register_job Dockerfile. This tag will eventually be changed back to a release version in the future.
  - [MCP_DEV branch](https://github.com/unity-sds/unity-sps-register_job/blob/MCP_DEV/docker/Dockerfile#L1)
  - [MCP_TEST branch](https://github.com/unity-sds/unity-sps-register_job/blob/MCP_TEST/docker/Dockerfile#L1)