### PR TITLE
Add support for job labels

### DIFF
--- a/jobs-database/es_templates/jobs_index_template.json
+++ b/jobs-database/es_templates/jobs_index_template.json
@@ -20,7 +20,7 @@
         "status": {
           "type": "keyword"
         },
-        "tags": {
+        "labels": {
           "enabled": false
         }
       }

--- a/terraform-modules/terraform-unity-sps-hysds-cluster/elastic.tf
+++ b/terraform-modules/terraform-unity-sps-hysds-cluster/elastic.tf
@@ -387,7 +387,7 @@ resource "null_resource" "upload_jobs_template" {
               "status": {
                 "type": "keyword"
               },
-              "tags": {
+              "labels": {
                 "enabled": false
               }
             }


### PR DESCRIPTION
## Purpose
- Make changes to the elasticsearch jobs index template and the jobs ingest lambda to support job labels.

## Proposed Changes
- [CHANGE] tags in jobs db index template to labels
- [CHANGE] jobs_data_ingest lambda now uses es's [update api](https://www.elastic.co/guide/en/elasticsearch/reference/8.8/docs-update.html) to prevent removal of missing fields caused by using the [index api](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html)

## Testing
- Elasticsearch label propagation was validated manually with jobs that had:

1.  No label field
2. A label field that contained an empty list
3. A label field with string labels

- validated that updates [pass regression tests](https://github.com/unity-sds/unity-sps-prototype/actions/runs/5604169321)

