### PR TITLE
Create sps api url ssm param

### DIFF
--- a/terraform-modules/terraform-unity-sps-hysds-cluster/sps_api.tf
+++ b/terraform-modules/terraform-unity-sps-hysds-cluster/sps_api.tf
@@ -20,17 +20,10 @@ resource "kubernetes_service" "sps-api-service" {
 }
 
 resource "aws_ssm_parameter" "sps-api-hostname-param" {
-  name        = "/unity/sps/${var.deployment_name}/spsApi/hostname"
+  name        = "/unity/sps/${var.deployment_name}/spsApi/url"
   description = "Hostname of sps api load balancer"
   type        = "String"
-  value       = kubernetes_service.sps-api-service.status[0].load_balancer[0].ingress[0].hostname
-}
-
-resource "aws_ssm_parameter" "sps-api-port-param" {
-  name        = "/unity/sps/${var.deployment_name}/spsApi/port"
-  description = "Port used by sps api"
-  type        = "String"
-  value       = var.service_port_map.sps_api_service
+  value       = "http://${kubernetes_service.sps-api-service.status[0].load_balancer[0].ingress[0].hostname}:${var.service_port_map.sps_api_service}"
 }
 
 resource "kubernetes_deployment" "sps-api" {


### PR DESCRIPTION
## Purpose
- Combines domain and port to single url ssm param for the sps api
## Proposed Changes
- [ADD] Create `/unity/sps/{cluster name}/spsApi/url` ssm param
## Issues
- [issue-222](https://github.com/unity-sds/unity-sps-prototype/issues/222)
## Testing
- Validated ssm parameter exists after successful deployment
