### PR TITLE
Redirecting to parent U-SPS repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,1 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [0.1.0] - 2022-04-20
-
-### Added 
-
-- First implementation of HySDS services as Docker containers
-- Shell scripts to deploy/undeploy all Docker containers onto local Kubernetes cluster using the kubectl client
-- Terraform scripts to deploy/undeploy all Docker containers onto local Kubernetes cluster using Terraform
-
+Please see the parent repository's [CHANGELOG.md](https://github.com/unity-sds/unity-sps/blob/main/CHANGELOG.md) for a history of changes.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# unity-sps-prototype
+<!-- Header block for project -->
+<hr>
+
+<div align="center">
+
+<!-- ☝️ Replace with your logo (if applicable) via ![](https://uri-to-your-logo-image) ☝️ -->
+<!-- ☝️ If you see logo rendering errors, make sure you're not using indentation, or try an HTML IMG tag -->
+
+<h1 align="center">Unity SPS Prototype</h1>
+<!-- ☝️ Replace with your repo name ☝️ -->
+
+</div>
+
+<pre align="center">This is a prototype repository related to Unity SPS.</pre>
+<!-- ☝️ Replace with a single sentence describing the purpose of your repo / proj ☝️ -->
+
+<!-- Header block for project -->
+
+<!-- ☝️ Add badges via: https://shields.io e.g. ![](https://img.shields.io/github/your_chosen_action/your_org/your_repo) ☝️ -->
+
+<!-- ☝️ Screenshot of your software (if applicable) via ![](https://uri-to-your-screenshot) ☝️ -->
+
+For detailed information about this repository and its purpose, please refer to the parent repository, Unity SPS, at [https://github.com/unity-sds/unity-sps](https://github.com/unity-sds/unity-sps).
+
+## Features
+
+* Please consult the parent repository [unity-sps](https://github.com/unity-sds/unity-sps) for features related to all Unity SPS repositories.
+
+<!-- ☝️ Replace with a bullet-point list of your features ☝️ -->
+
+## Contents
+
+* [Quick Start](#quick-start)
+* [Changelog](#changelog)
+* [FAQ](#frequently-asked-questions-faq)
+* [Contributing Guide](#contributing)
+* [License](#license)
+* [Support](#support)
+
+## Quick Start
+
+For comprehensive details, guidelines, and documentation, refer to the parent repository: [unity-sps](https://github.com/unity-sds/unity-sps).
+
+
+## Changelog
+
+Please see the parent repository's [CHANGELOG.md](https://github.com/unity-sds/unity-sps/blob/main/CHANGELOG.md) for a history of changes.
+
+## Frequently Asked Questions (FAQ)
+
+For any questions, consult the FAQ of the parent repository [unity-sps](https://github.com/unity-sds/unity-sps).
+
+## Contributing
+
+To contribute, kindly refer to the guidelines in the parent repository: [unity-sps](https://github.com/unity-sds/unity-sps).
+
+## License
+
+See our: [LICENSE](LICENSE)
+
+## Support
+
+For support, please contact the maintainers of the parent repository [unity-sps](https://github.com/unity-sds/unity-sps).


### PR DESCRIPTION
## Purpose
- Redirecting the user to the parent U-SPS repository. 
- The changes made to the files _should_ show green for the new [Unity standards compliance leaderboard](https://github.com/unity-sds/unity-project-management/blob/main/standards-compliance/leaderboard.md) (will need to test once merged). 
## Proposed Changes
- [CHANGE] README contents
- [CHANGE] CHANGELOG contents
## Issues
- N/A
## Testing
- See example: https://github.com/riverma/unity-sps-prototype
