### PR TITLE
add post start exec to rabbitmq container that increases consumer_tim…

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-hysds-cluster/rabbitmq.tf
+++ b/terraform-unity/modules/terraform-unity-sps-hysds-cluster/rabbitmq.tf
@@ -88,6 +88,9 @@ resource "kubernetes_stateful_set" "rabbitmq_statefulset" {
                   rabbitmqctl eval 'application:set_env(rabbit, consumer_timeout, 172800000).'
                   EOT
                 ]
+              }
+            }
+          }
           volume_mount {
             mount_path = "/var/lib/rabbitmq"
             name       = "rabbitmq-data"

--- a/terraform-unity/modules/terraform-unity-sps-hysds-cluster/rabbitmq.tf
+++ b/terraform-unity/modules/terraform-unity-sps-hysds-cluster/rabbitmq.tf
@@ -78,6 +78,16 @@ resource "kubernetes_stateful_set" "rabbitmq_statefulset" {
             name  = "RABBITMQ_ERLANG_COOKIE"
             value = "1WqgH8N2v1qDBDZDbNy8Bg9IkPWLEpu79m6q+0t36lQ="
           }
+          lifecycle {
+            post_start {
+              exec {
+                command = [
+                  "/bin/sh",
+                  "-c",
+                  <<-EOT
+                  rabbitmqctl eval 'application:set_env(rabbit, consumer_timeout, 172800000).'
+                  EOT
+                ]
           volume_mount {
             mount_path = "/var/lib/rabbitmq"
             name       = "rabbitmq-data"


### PR DESCRIPTION
## Purpose
- Fix retry issue caused by consumer timeout
## Proposed Changes
- [ADD] post-start exec script to rabbitmq container
## Issues
- Fixes bug [#247](https://github.com/unity-sds/unity-sps-prototype/issues/247)
## Testing
- Testing needs to be done before this can be merged