### PR TITLE
251 backoff verbosity

### DIFF
--- a/unity-test/step_defs/conftest.py
+++ b/unity-test/step_defs/conftest.py
@@ -6,10 +6,12 @@ from urllib.parse import urljoin
 import re
 from . import TEST_BASE_DIR
 from .utils import JsonReader
+import logging
 
 
 FEATURES_DIR = TEST_BASE_DIR.joinpath("features")
 reader = JsonReader()
+logging.getLogger('backoff').setLevel(logging.ERROR)
 
 
 def pytest_addoption(parser):

--- a/unity-test/step_defs/conftest.py
+++ b/unity-test/step_defs/conftest.py
@@ -6,12 +6,9 @@ from urllib.parse import urljoin
 import re
 from . import TEST_BASE_DIR
 from .utils import JsonReader
-import logging
-
 
 FEATURES_DIR = TEST_BASE_DIR.joinpath("features")
 reader = JsonReader()
-logging.getLogger('backoff').setLevel(logging.ERROR)
 
 
 def pytest_addoption(parser):

--- a/unity-test/step_defs/test_get_processing_status.py
+++ b/unity-test/step_defs/test_get_processing_status.py
@@ -28,9 +28,9 @@ def created_response(response):
 @backoff.on_exception(
     backoff.constant,
     (requests.exceptions.HTTPError),
-    max_time=3600,
+    max_time=60,
     jitter=None,
-    interval=1,
+    interval=10,
 )
 def request_job_status_by_id(process_service_endpoint, project_process_dict, job_id):
     return _request_job_status_by_id(

--- a/unity-test/step_defs/test_get_processing_status.py
+++ b/unity-test/step_defs/test_get_processing_status.py
@@ -30,6 +30,7 @@ def created_response(response):
     (requests.exceptions.HTTPError),
     max_time=60,
     jitter=None,
+    logger=None,
     interval=10,
 )
 def request_job_status_by_id(process_service_endpoint, project_process_dict, job_id):

--- a/unity-test/step_defs/test_job_database_status.py
+++ b/unity-test/step_defs/test_job_database_status.py
@@ -48,7 +48,8 @@ def fatal_status(e):
     max_time=3600,
     giveup=fatal_status,
     jitter=None,
-    interval=0.1, # check more frequently since jobs can execute quickly
+    logger=None,
+    interval=1, # check more frequently since jobs can execute quickly
 )
 def request_job_status_by_id_running(process_service_endpoint, project_process_dict, job_id):
     job_status_response = _request_job_status_by_id(
@@ -69,9 +70,10 @@ def request_job_status_by_id_running(process_service_endpoint, project_process_d
 @backoff.on_exception(
     backoff.constant,
     (AssertionError, requests.exceptions.HTTPError),
-    max_time=3600,
+    max_time=60,
     giveup=fatal_status,
     jitter=None,
+    logger=None,
     interval=1,
 )
 def request_job_status_by_id_succeeded(process_service_endpoint, project_process_dict, job_id):

--- a/unity-test/step_defs/test_successful_execution.py
+++ b/unity-test/step_defs/test_successful_execution.py
@@ -38,7 +38,8 @@ def fatal_status(e):
     max_time=3600,
     giveup=fatal_status,
     jitter=None,
-    interval=1,
+    logger=None,
+    interval=5,
 )
 def request_job_status_by_id(process_service_endpoint, project_process_dict, job_id):
     job_status_response = _request_job_status_by_id(


### PR DESCRIPTION
## Purpose
- Reduce the verbosity of the logs when executing tests, which now it's making debugging failed tests pretty difficult
## Proposed Changes
- Change the parameters of the @backoff decorator to reduce the number of failed attempts, and stop logging unnecessary output
## Issues
- https://github.com/unity-sds/unity-sps-prototype/issues/251
## Testing
- See result of failed tests when using this branch: https://github.com/unity-sds/unity-sps-prototype/actions/runs/7399949377 
